### PR TITLE
Add integration tests and tooling for chatbot runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.venv/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: install run chat test
+
+install:
+	pip install -r requirements.txt
+
+run:
+	uvicorn customer_support.api:app --reload
+
+chat:
+	python -m customer_support.cli
+
+test:
+	pytest

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# Customer-Support
+# Customer Support Chatbot
+
+This repository houses the source code and planning artifacts for a customer support virtual assistant. The goal is to deliver a guided, trustworthy, and insight-driven experience that resolves the majority of subscriber issues without human intervention.
+
+## Project Structure
+- `docs/chatbot_blueprint.md` – Strategic blueprint covering product vision, capabilities, and roadmap.
+- `docs/implementation_plan.md` – Discovery notes and MVP delivery plan for the first functional release.
+- `data/knowledge_base.json` – Canonical intents and scripted responses for the MVP chatbot.
+- `src/customer_support/` – FastAPI application, rule-based engine, and CLI utilities.
+- `tests/` – Automated unit tests covering core chatbot behavior.
+
+## Getting Started
+1. **Create a virtual environment** (optional but recommended):
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. **Install dependencies**:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. **Run the API locally**:
+   ```bash
+   uvicorn customer_support.api:app --reload
+   ```
+   or use the provided shortcuts:
+   ```bash
+   make run   # start the FastAPI server on http://127.0.0.1:8000
+   make chat  # launch the interactive CLI tester
+   ```
+4. **Interact with the chatbot**:
+   - Send REST requests to `POST /chat` with JSON `{ "session_id": "demo", "message": "I have a billing issue" }`.
+   - Exercise the automated smoke tests to confirm the endpoints function end-to-end:
+     ```bash
+     make test
+     ```
+   - Use the CLI helper for a quick terminal experience:
+     ```bash
+     python -m customer_support.cli
+     ```
+
+## Next Steps
+The MVP focuses on scripted flows for top intents. Future iterations will integrate a richer knowledge base, analytics instrumentation, multilingual support, and web/mobile chat widgets.

--- a/data/knowledge_base.json
+++ b/data/knowledge_base.json
@@ -1,0 +1,58 @@
+[
+  {
+    "intent": "greeting",
+    "utterances": ["hi", "hello", "hey there", "good morning", "good evening"],
+    "response": {
+      "text": "Hi there! I'm your Customer Care Assistant. I can help with billing, account access, live events, and device setup. What can I assist you with today?",
+      "suggestions": ["Billing question", "Trouble logging in", "How to watch live events"]
+    }
+  },
+  {
+    "intent": "billing",
+    "utterances": ["billing issue", "charge on my account", "incorrect bill", "payment failed", "update my card"],
+    "response": {
+      "text": "It sounds like you have a billing question. Here's what I can do:\n1. Check your subscription status.\n2. Update payment details.\n3. Review recent charges.\nIf you'd like to speak with a specialist, I can collect a few details and start a ticket.",
+      "form": {
+        "title": "Billing support",
+        "fields": [
+          {"name": "full_name", "label": "Full name", "type": "text", "required": true},
+          {"name": "email", "label": "Email address", "type": "email", "required": true},
+          {"name": "billing_issue", "label": "Tell us about the billing issue", "type": "textarea", "required": true}
+        ]
+      },
+      "suggestions": ["Review subscription status", "Update payment method", "Talk to an agent"]
+    }
+  },
+  {
+    "intent": "login_help",
+    "utterances": ["can't log in", "forgot password", "trouble signing in", "login help", "reset password"],
+    "response": {
+      "text": "Let's get you back into your account. Try these steps:\n• Make sure you're using the email connected to your subscription.\n• If you forgot your password, use the **Reset Password** option on the sign-in page.\n• Still locked out? I can trigger a password reset email for you.",
+      "suggestions": ["Send me a reset email", "Still can't sign in", "Something else"]
+    }
+  },
+  {
+    "intent": "live_event",
+    "utterances": ["watch live event", "devices for live events", "streaming live game", "best device for matches", "live event schedule"],
+    "response": {
+      "text": "We stream live events on web, iOS, Android, Roku, Apple TV, Amazon Fire TV, and Android TV. For the best experience, use a wired connection and close other streaming apps. Need the upcoming schedule?",
+      "suggestions": ["Show live event schedule", "Recommended devices", "Talk to an agent"]
+    }
+  },
+  {
+    "intent": "goodbye",
+    "utterances": ["thank you", "thanks", "bye", "goodbye", "appreciate it"],
+    "response": {
+      "text": "Happy to help! If anything else comes up, just let me know. Have a great day!",
+      "suggestions": ["Start over", "No, that's all"]
+    }
+  },
+  {
+    "intent": "fallback",
+    "utterances": [],
+    "response": {
+      "text": "I'm not sure I have that answer yet. Could you rephrase your question or pick one of the options below? If you'd prefer, I can connect you with a human specialist.",
+      "suggestions": ["Billing question", "Trouble logging in", "Talk to an agent"]
+    }
+  }
+]

--- a/docs/chatbot_blueprint.md
+++ b/docs/chatbot_blueprint.md
@@ -1,0 +1,107 @@
+# Customer Support Chatbot Blueprint
+
+## 1. Product Vision
+Design an omnichannel virtual assistant that can resolve the majority of subscriber support inquiries instantly while preserving a smooth handoff to human agents for complex cases. The assistant should blend conversational AI with rich UI widgets to mimic the polished experiences illustrated in the reference screenshots.
+
+## 2. Experience Principles
+1. **Trustworthy & Proactive** – Surface relevant answers, policies, and troubleshooting steps before a user needs to ask follow-up questions.
+2. **Guided Interactions** – Present quick-reply chips, carousels, and rich articles that help users discover the right workflow in one tap.
+3. **Human-Ready** – Capture all context (contact information, device, issue details) and provide transparent handoff when escalation is required.
+4. **Insight-Driven** – Collect structured data on every conversation to fuel analytics, churn prevention, and product improvements.
+
+## 3. Key Personas & Use Cases
+- **New Subscribers** – Onboarding help, device compatibility, pricing questions.
+- **Active Subscribers** – Billing, coupon redemption, streaming quality, login issues.
+- **Lapsed / At-Risk Users** – Incentives, tailored messaging, retention outreach.
+
+## 4. Core Capabilities
+### 4.1 Conversational Foundations
+- Multilingual NLU models covering top 5–10 markets (English, Spanish, French, German, Portuguese, etc.).
+- Intent detection, entity extraction, and sentiment analysis to route flows.
+- Context retention across turns with conversation memory, including user profile, device, and subscription tier.
+
+### 4.2 Guided UI Elements
+- **Quick Reply Chips** mirroring "What devices to use for _ live games" or "I have a coupon question" for top intents.
+- **Article Cards** with image, title, summary, and action buttons (e.g., *View article*, *Read more*).
+- **Feedback Widgets** with Yes/No or 1–5 rating after each resolution.
+- **Dynamic Forms** (name, email, device, issue, live-event question) before escalation, similar to MXGP example.
+- **CTA Buttons** (e.g., *Contact Sales*, *Talk to an agent*) persistent at bottom of widget.
+
+### 4.3 Knowledge & Automation
+- CMS-driven knowledge base with versioned articles and auto-suggest.
+- API integrations for account lookup, subscription status, transaction history, entitlement refresh, coupon validation.
+- Automated workflows: password reset, device activation, refund status, outage notifications.
+
+### 4.4 Escalation & Handover
+- Queue selection (billing, tech support, retention).
+- Real-time agent console that displays full transcript, captured form data, and AI recommendations.
+- Email fallback for out-of-hours requests.
+
+### 4.5 Analytics & Insights
+- Real-time dashboard for conversation volume, CSAT, containment rate, intent distribution.
+- Contact reason analysis with trend alerts (mirroring sample analytics screenshot).
+- Persona-based segmentation to personalize offers.
+- Export to BI tools and CRM for LTV tracking.
+
+## 5. Conversation Architecture
+1. **Greeting Layer**
+   - Personalized welcome message using name (if authenticated) or location.
+   - Present top intents as quick replies and an open-text input.
+2. **Intent Resolution Paths**
+   - **Self-Service Flows**: Provide rich article cards, step-by-step instructions, decision trees.
+   - **Troubleshooting Bot**: Interactive forms collecting necessary details and recommending next steps.
+   - **Sales Guidance**: Present carousel of plans, pricing calculators, and CTA to contact sales.
+3. **Fallback & Learning**
+   - Confidence threshold logic: below threshold triggers clarifying questions or agent handoff.
+   - Feedback capture stored for tuning and knowledge gap detection.
+
+## 6. Technical Architecture
+- **Frontend**: Responsive web widget (React/Vue) embeddable in web, mobile, and smart TV apps. Support white-label branding (colors, logos, typography).
+- **Backend**: Node.js or Python microservices orchestrating NLU, knowledge base, and integrations.
+- **NLU Platform**: Consider Google Dialogflow CX, Microsoft Bot Framework with LUIS, or open-source Rasa. Augment with LLM-based retrieval-augmented generation (RAG) for long-form answers.
+- **Knowledge Base**: Markdown/HTML articles stored in headless CMS (Contentful, Strapi) and indexed in vector store (Pinecone, Weaviate) for semantic search.
+- **Analytics Pipeline**: Event streaming (Kafka/Kinesis) into data warehouse (Snowflake/BigQuery) with Looker/Mode dashboards.
+- **Security**: OAuth 2.0 / SSO for authenticated experiences, GDPR-compliant data retention, PII encryption at rest and in transit.
+
+## 7. Integration Checklist
+- Subscription platform (e.g., Cleeng, Stripe, Recurly) for billing inquiries.
+- CRM/Helpdesk (Zendesk, Salesforce Service Cloud) for ticket sync.
+- Email & push notification services for follow-ups.
+- Incident management feed to push outage banners into chat.
+
+## 8. Analytics Requirements
+- **Metrics**: First response time, containment rate, escalation rate, resolution time, CSAT, NPS, churn propensity.
+- **Dashboards**: Intent breakdown by period, device type, region; trending issues; agent utilization; automation savings.
+- **Alerts**: Spike detection for certain intents (e.g., "can't access subscription").
+
+## 9. Content & Tone Guidelines
+- Friendly, concise, brand-aligned voice.
+- Provide empathy for sensitive issues (billing, outages).
+- Offer proactive suggestions and relevant help articles.
+- Always confirm whether the answer solved the problem.
+
+## 10. Implementation Roadmap
+1. **Discovery (Weeks 1–3)**
+   - Audit existing support data, define intents, gather FAQs.
+   - Map integrations and security requirements.
+2. **MVP (Weeks 4–10)**
+   - Build core flows for top 10 intents with quick replies and article cards.
+   - Implement analytics baseline and agent handoff.
+3. **Expansion (Weeks 11–20)**
+   - Add multilingual support, personalization, proactive outreach.
+   - Deploy advanced analytics, churn prediction, and marketing integrations.
+4. **Optimization (Ongoing)**
+   - Continuous training, A/B testing, knowledge updates, and feedback loops.
+
+## 11. Success Criteria
+- 70%+ containment rate within six months.
+- 20% reduction in ticket handling time.
+- CSAT ≥ 4.5/5 for bot-assisted resolutions.
+- Demonstrated lift in subscriber retention for cohorts interacting with the assistant.
+
+## 12. Next Steps
+- Prioritize intents based on recent support data.
+- Choose NLU platform and integration partners.
+- Create UI prototypes reflecting reference designs.
+- Draft knowledge base articles and macro responses.
+- Establish feedback and analytics instrumentation plan.

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -1,0 +1,37 @@
+# Customer Support Chatbot – MVP Implementation Plan
+
+This document captures the discovery notes, design decisions, and backlog for the first functional release of the customer support chatbot. It distills the broader blueprint into concrete workstreams for the MVP.
+
+## 1. Discovery Highlights
+- **Top intents to support first:** billing questions, login help, live event access, general greeting/help, graceful fallbacks.
+- **Tone & brand:** friendly, concise, confident. Empathy for sensitive issues (billing, outages).
+- **Channels:** Start with a web widget + REST API. CLI provided for quick demos.
+- **Success criteria for MVP:** response latency under 500 ms for scripted intents, clear escalation path, ability to capture structured data for billing cases.
+
+## 2. Architecture Snapshot
+```
+User -> Web Widget / CLI -> FastAPI backend -> Rule-based engine -> JSON knowledge base
+```
+- **Backend:** Python FastAPI app served via Uvicorn.
+- **Knowledge base:** JSON file with canonical utterances, responses, and optional forms.
+- **Engine:** Lightweight intent matching via fuzzy similarity (difflib) with fallback handling.
+- **State:** In-memory session memory storing last intent and future slot data.
+
+## 3. Functional Scope for First Release
+1. **Conversational flows** for greeting, billing, login help, live events, goodbye, and fallback.
+2. **Structured responses** including suggestions and forms for data capture.
+3. **REST endpoints** for health check, listing intents, chatting, and resetting a session.
+4. **Developer tooling**: CLI runner and automated unit tests for billing/fallback coverage.
+
+## 4. Backlog & Next Steps
+- Add analytics hooks (event logging per turn).
+- Persist session memory to Redis or database for scalability.
+- Expand knowledge base and integrate with CMS or external APIs.
+- Implement authentication for authenticated user context.
+- Build React widget consuming the REST API with quick replies and forms.
+
+## 5. Operational Runbook
+- Install dependencies with `pip install -r requirements.txt`.
+- Start the API locally: `uvicorn customer_support.api:app --reload`.
+- Run tests with `pytest`.
+- Monitor logs for slow requests; adjust threshold for intent detection as knowledge base grows.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+pythonpath = src
+filterwarnings =
+    ignore:The 'app' shortcut is now deprecated.:DeprecationWarning:httpx._client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+pydantic==1.10.14
+httpx==0.27.0
+pytest==8.2.2

--- a/src/customer_support/__init__.py
+++ b/src/customer_support/__init__.py
@@ -1,0 +1,1 @@
+"""Customer Support chatbot package."""

--- a/src/customer_support/api.py
+++ b/src/customer_support/api.py
@@ -1,0 +1,70 @@
+"""FastAPI application exposing the chatbot engine."""
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+from fastapi import Body, Depends, FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .engine import ChatbotEngine
+from .knowledge import KnowledgeBase
+
+app = FastAPI(title="Customer Support Chatbot", version="0.1.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"]
+)
+
+
+def kb_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "data" / "knowledge_base.json"
+
+
+@lru_cache()
+def knowledge_base() -> KnowledgeBase:
+    return KnowledgeBase.from_json(kb_path())
+
+
+@lru_cache()
+def engine() -> ChatbotEngine:
+    return ChatbotEngine(knowledge_base())
+
+
+@app.get("/health")
+def healthcheck() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/intents")
+def list_intents(kb: KnowledgeBase = Depends(knowledge_base)) -> Dict[str, Dict[str, Any]]:
+    return kb.to_dict()
+
+
+@app.post("/chat")
+def chat(payload: Dict[str, Any] = Body(...), bot: ChatbotEngine = Depends(engine)) -> Dict[str, Any]:
+    session_id = str(payload.get("session_id", "anon"))
+    message = str(payload.get("message", "")).strip()
+    if not message:
+        return {
+            "session_id": session_id,
+            "intent": "fallback",
+            "confidence": 0.0,
+            "response": {
+                "text": "Could you share a bit more detail so I can assist you?",
+                "suggestions": ["Billing question", "Trouble logging in", "Talk to an agent"],
+            },
+            "memory": {},
+        }
+
+    response = bot.respond(session_id, message)
+    return response.to_dict()
+
+
+@app.post("/sessions/{session_id}/reset")
+def reset_session(session_id: str, bot: ChatbotEngine = Depends(engine)) -> Dict[str, str]:
+    bot.reset_session(session_id)
+    return {"status": "reset", "session_id": session_id}

--- a/src/customer_support/cli.py
+++ b/src/customer_support/cli.py
@@ -1,0 +1,33 @@
+"""Simple command line interface for manual testing of the chatbot engine."""
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+from .engine import ChatbotEngine
+from .knowledge import KnowledgeBase
+
+
+def run_cli() -> None:
+    kb_path = Path(__file__).resolve().parents[2] / "data" / "knowledge_base.json"
+    engine = ChatbotEngine(KnowledgeBase.from_json(kb_path))
+    session_id = str(uuid.uuid4())
+    print("Customer Support Assistant (type 'exit' to quit)")
+
+    while True:
+        message = input("You: ").strip()
+        if message.lower() in {"exit", "quit"}:
+            break
+        if not message:
+            continue
+        response = engine.respond(session_id, message)
+        print(f"Bot [{response.intent} @ {response.confidence:.2f}]: {response.response.text}")
+        if response.response.suggestions:
+            print("Suggestions:")
+            for suggestion in response.response.suggestions:
+                print(f"  - {suggestion}")
+    print("Goodbye!")
+
+
+if __name__ == "__main__":
+    run_cli()

--- a/src/customer_support/engine.py
+++ b/src/customer_support/engine.py
@@ -1,0 +1,73 @@
+"""Core rule-based chatbot engine."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Dict
+
+from .knowledge import KnowledgeBase
+from .models import ChatResponse, Intent, Memory, ResponsePayload
+
+
+@dataclass
+class MatchResult:
+    intent: Intent
+    confidence: float
+
+
+class ChatbotEngine:
+    """Tiny rule-based engine capable of serving MVP chat requests."""
+
+    def __init__(self, knowledge_base: KnowledgeBase, threshold: float = 0.55):
+        self.knowledge_base = knowledge_base
+        self.threshold = threshold
+        self._memory: Dict[str, Memory] = {}
+
+    def _memory_for(self, session_id: str) -> Memory:
+        if session_id not in self._memory:
+            self._memory[session_id] = Memory(session_id=session_id)
+        return self._memory[session_id]
+
+    def _similarity(self, a: str, b: str) -> float:
+        return SequenceMatcher(None, a.lower(), b.lower()).ratio()
+
+    def _match_intent(self, text: str) -> MatchResult:
+        best_intent = None
+        best_score = 0.0
+        normalized = text.strip().lower()
+
+        for intent in self.knowledge_base.intents():
+            if not intent.utterances:
+                continue
+            for utterance in intent.utterances:
+                score = self._similarity(normalized, utterance)
+                if score > best_score:
+                    best_score = score
+                    best_intent = intent
+
+        if best_intent and best_score >= self.threshold:
+            return MatchResult(intent=best_intent, confidence=best_score)
+
+        fallback = self.knowledge_base.get("fallback")
+        return MatchResult(intent=fallback, confidence=best_score)
+
+    def respond(self, session_id: str, message: str) -> ChatResponse:
+        memory = self._memory_for(session_id)
+        match = self._match_intent(message)
+
+        memory.last_intent = match.intent.name
+        response_payload: ResponsePayload = match.intent.response
+
+        return ChatResponse(
+            session_id=session_id,
+            intent=match.intent.name,
+            confidence=round(match.confidence, 3),
+            response=response_payload,
+            memory=memory.slots,
+        )
+
+    def reset_session(self, session_id: str) -> None:
+        self._memory.pop(session_id, None)
+
+    def stats(self) -> Dict[str, Dict[str, list]]:
+        return self.knowledge_base.to_dict()

--- a/src/customer_support/knowledge.py
+++ b/src/customer_support/knowledge.py
@@ -1,0 +1,45 @@
+"""Knowledge base loader for the customer support chatbot."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from .models import Intent, ResponsePayload
+
+
+class KnowledgeBase:
+    """Loads and stores intents defined in a JSON file."""
+
+    def __init__(self, intents: List[Intent]):
+        self._intents = {intent.name: intent for intent in intents}
+
+    @classmethod
+    def from_json(cls, path: Path) -> "KnowledgeBase":
+        raw = json.loads(path.read_text())
+        intents: List[Intent] = []
+        for entry in raw:
+            response = ResponsePayload.from_dict(entry["response"])
+            intents.append(
+                Intent(
+                    name=entry["intent"],
+                    utterances=[u.lower() for u in entry.get("utterances", [])],
+                    response=response,
+                )
+            )
+        return cls(intents)
+
+    def intents(self) -> Iterable[Intent]:
+        return self._intents.values()
+
+    def get(self, name: str) -> Intent:
+        return self._intents[name]
+
+    def to_dict(self) -> Dict[str, Dict[str, List[str]]]:
+        return {
+            intent.name: {
+                "utterances": intent.utterances,
+                "suggestions": intent.response.suggestions,
+            }
+            for intent in self._intents.values()
+        }

--- a/src/customer_support/models.py
+++ b/src/customer_support/models.py
@@ -1,0 +1,114 @@
+"""Domain models for the customer support chatbot."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class FormField:
+    """Schema for a dynamic form field shown to the user."""
+
+    name: str
+    label: str
+    type: str
+    required: bool = False
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "FormField":
+        return cls(
+            name=str(data["name"]),
+            label=str(data.get("label", "")),
+            type=str(data.get("type", "text")),
+            required=bool(data.get("required", False)),
+        )
+
+
+@dataclass
+class FormSchema:
+    """Dynamic form attached to an intent response."""
+
+    title: str
+    fields: List[FormField] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "FormSchema":
+        fields = [FormField.from_dict(f) for f in data.get("fields", [])]
+        return cls(title=str(data.get("title", "")), fields=fields)
+
+
+@dataclass
+class ResponsePayload:
+    """Response payload returned for a resolved intent."""
+
+    text: str
+    suggestions: List[str] = field(default_factory=list)
+    form: Optional[FormSchema] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "ResponsePayload":
+        form_data = data.get("form")
+        form = FormSchema.from_dict(form_data) if isinstance(form_data, dict) else None
+        return cls(
+            text=str(data.get("text", "")),
+            suggestions=[str(item) for item in data.get("suggestions", [])],
+            form=form,
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "text": self.text,
+            "suggestions": list(self.suggestions),
+        }
+        if self.form:
+            payload["form"] = {
+                "title": self.form.title,
+                "fields": [field.__dict__ for field in self.form.fields],
+            }
+        return payload
+
+
+@dataclass
+class Intent:
+    """Canonical intent description loaded from the knowledge base."""
+
+    name: str
+    utterances: List[str]
+    response: ResponsePayload
+
+
+@dataclass
+class Memory:
+    """Conversation state tracked across user turns."""
+
+    session_id: str
+    last_intent: Optional[str] = None
+    slots: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class ChatRequest:
+    """Incoming message payload for the API."""
+
+    message: str
+    session_id: str = "anon"
+
+
+@dataclass
+class ChatResponse:
+    """Response returned by the chatbot engine via the API."""
+
+    session_id: str
+    intent: str
+    confidence: float
+    response: ResponsePayload
+    memory: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "session_id": self.session_id,
+            "intent": self.intent,
+            "confidence": self.confidence,
+            "response": self.response.to_dict(),
+            "memory": dict(self.memory),
+        }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,60 @@
+"""Integration-style tests for the FastAPI chatbot service."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from customer_support.api import app
+
+
+client = TestClient(app)
+
+
+def test_healthcheck() -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_list_intents_includes_billing() -> None:
+    response = client.get("/intents")
+    payload = response.json()
+    assert response.status_code == 200
+    assert "billing" in payload
+    assert "utterances" in payload["billing"]
+    assert "charge on my account" in payload["billing"]["utterances"]
+
+
+def test_chat_returns_expected_intent() -> None:
+    response = client.post(
+        "/chat",
+        json={"session_id": "test", "message": "hello"},
+    )
+    body = response.json()
+    assert response.status_code == 200
+    assert body["intent"] == "greeting"
+    assert body["session_id"] == "test"
+    assert body["confidence"] >= 0.55
+    assert "Hi there" in body["response"]["text"]
+
+
+def test_chat_handles_blank_message_with_fallback() -> None:
+    response = client.post(
+        "/chat",
+        json={"session_id": "blank", "message": ""},
+    )
+    body = response.json()
+    assert response.status_code == 200
+    assert body["intent"] == "fallback"
+    assert body["confidence"] == 0.0
+    assert "share a bit more detail" in body["response"]["text"]
+
+
+def test_reset_session_clears_memory() -> None:
+    response = client.post(
+        "/chat",
+        json={"session_id": "reset-me", "message": "billing issue"},
+    )
+    assert response.status_code == 200
+    reset_response = client.post("/sessions/reset-me/reset")
+    assert reset_response.status_code == 200
+    assert reset_response.json() == {"status": "reset", "session_id": "reset-me"}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from customer_support.engine import ChatbotEngine
+from customer_support.knowledge import KnowledgeBase
+
+
+def load_engine() -> ChatbotEngine:
+    kb_path = Path(__file__).resolve().parents[1] / "data" / "knowledge_base.json"
+    kb = KnowledgeBase.from_json(kb_path)
+    return ChatbotEngine(kb)
+
+
+def test_engine_matches_billing_intent():
+    engine = load_engine()
+
+    response = engine.respond("test", "I have a billing issue")
+
+    assert response.intent == "billing"
+    assert "billing" in response.response.text.lower()
+
+
+def test_engine_falls_back_for_unknown():
+    engine = load_engine()
+
+    response = engine.respond("test", "Tell me about space rockets")
+
+    assert response.intent == "fallback"
+    assert "not sure" in response.response.text.lower()


### PR DESCRIPTION
## Summary
- add Makefile helper targets to install dependencies, run the API, launch the CLI, and execute tests
- document the new shortcuts in the README and capture automated smoke-test guidance
- add missing client/test dependencies, filter deprecated warnings, and cover the FastAPI endpoints with integration tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e65f49cf0083278aeca695ca41f63b