### PR TITLE
Fix local run instructions for FastAPI UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+*.log
+*.swp
+*.tmp
+.venv/
+build/
+dist/
+.pytest_cache/
+.env
+.env.*
+.git
+.gitignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest
+
+      - name: Build Docker image
+        run: docker build -t customer-support-chatbot:ci .

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH="/app/src"
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src ./src
+COPY data ./data
+
+EXPOSE 8000
+
+CMD ["uvicorn", "customer_support.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+.PHONY: install run test demo docker-build docker-run docker-push deploy
+
+IMAGE_NAME ?= customer-support-chatbot
+IMAGE_TAG ?= latest
+IMAGE_REF := $(IMAGE_NAME):$(IMAGE_TAG)
+APP_DIR ?= src
+
+install:
+	pip install -r requirements.txt
+
+run:
+	uvicorn --app-dir $(APP_DIR) customer_support.api:app --reload
+
+test:
+	pytest
+
+demo:
+	python scripts/demo_chat.py
+
+docker-build:
+	docker build -t $(IMAGE_REF) .
+
+docker-run:
+	docker run --rm -p 8000:8000 $(IMAGE_REF)
+
+docker-push:
+	@if [ "$(IMAGE_NAME)" = "customer-support-chatbot" ] && [ "$(IMAGE_TAG)" = "latest" ]; then \
+	echo "Pushing with default name/tag; override IMAGE_NAME or IMAGE_TAG if you need a different registry target."; \
+	fi
+	docker push $(IMAGE_REF)
+
+deploy: docker-build docker-run

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ This repository houses the source code and planning artifacts for a customer sup
    make run
    ```
    Once running, visit the fully featured web chat at [http://127.0.0.1:8000/](http://127.0.0.1:8000/) for a guided UI that mirrors
-   the reference designs. The interactive API docs remain available at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs) if you
-   prefer to exercise the endpoints directly.
+   the reference designs. The browser client offers quick-reply chips, dynamic billing forms, typing indicators, and automatic
+   transcript recovery so you can watch the experience update in real time. The interactive API docs remain available at
+   [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs) if you prefer to exercise the endpoints directly.
 4. **Interact with the chatbot**:
    - Send REST requests to `POST /chat` with JSON `{ "session_id": "demo", "message": "I have a billing issue" }`. Each response now echoes the running conversation history so you can render transcripts on the client side.
    - Retrieve the active session memory and transcript with `GET /sessions/{session_id}` or reset it via `POST /sessions/{session_id}/reset`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,111 @@
-# Customer-Support
+# Customer Support Chatbot
+
+This repository houses the source code and planning artifacts for a customer support virtual assistant. The goal is to deliver a guided, trustworthy, and insight-driven experience that resolves the majority of subscriber issues without human intervention.
+
+## Project Structure
+- `docs/chatbot_blueprint.md` – Strategic blueprint covering product vision, capabilities, and roadmap.
+- `docs/implementation_plan.md` – Discovery notes and MVP delivery plan for the first functional release.
+- `data/knowledge_base.json` – Canonical intents and scripted responses for the MVP chatbot.
+- `src/customer_support/` – FastAPI application, rule-based engine, and CLI utilities.
+- `tests/` – Automated unit tests covering core chatbot behavior.
+
+## Getting Started
+1. **Create a virtual environment** (optional but recommended):
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. **Install dependencies**:
+   ```bash
+   pip install -r requirements.txt
+   ```
+   Or, use the Make target to bootstrap the environment in one step:
+   ```bash
+   make install
+   ```
+3. **Run the API locally**:
+   ```bash
+   uvicorn --app-dir src customer_support.api:app --reload
+   ```
+   Or, using the provided shortcut (which sets the same flag for you):
+   ```bash
+   make run
+   ```
+   Once running, visit the fully featured web chat at [http://127.0.0.1:8000/](http://127.0.0.1:8000/) for a guided UI that mirrors
+   the reference designs. The interactive API docs remain available at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs) if you
+   prefer to exercise the endpoints directly.
+4. **Interact with the chatbot**:
+   - Send REST requests to `POST /chat` with JSON `{ "session_id": "demo", "message": "I have a billing issue" }`. Each response now echoes the running conversation history so you can render transcripts on the client side.
+   - Retrieve the active session memory and transcript with `GET /sessions/{session_id}` or reset it via `POST /sessions/{session_id}/reset`.
+   - Use the CLI helper for a quick terminal experience:
+     ```bash
+     python -m customer_support.cli
+     ```
+   - Replay the scripted smoke test conversation without starting the API:
+     ```bash
+     python scripts/demo_chat.py
+     ```
+5. **Run tests**:
+   ```bash
+   pytest
+   ```
+   Or run the full suite via Make:
+   ```bash
+   make test
+   ```
+
+## Containerized Deployment
+
+Build and run the chatbot in a self-contained Docker image:
+
+```bash
+make docker-build
+make docker-run
+```
+
+Or perform both steps in one go:
+
+```bash
+make deploy
+```
+
+To publish the image to your container registry, override the image reference and push:
+
+```bash
+make docker-build IMAGE_NAME=registry.example.com/my-team/customer-support IMAGE_TAG=v1
+make docker-push IMAGE_NAME=registry.example.com/my-team/customer-support IMAGE_TAG=v1
+```
+
+The defaults (`customer-support-chatbot:latest`) remain suitable for local testing.
+
+The API will be available on [http://127.0.0.1:8000](http://127.0.0.1:8000); visit `/docs` for the interactive interface. To stop the container, press <kbd>Ctrl</kbd>+<kbd>C</kbd> (or run `docker ps` and `docker stop` if launched in detached mode).
+
+## Continuous Integration
+
+This repository includes a GitHub Actions workflow that installs dependencies, executes the test suite, and builds the Docker image on every push and pull request. The workflow lives in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and keeps the chatbot deployable by catching regressions before they reach production.
+
+## Publishing to GitHub
+
+To link a freshly cloned workspace to the public repository and push your commits, configure the remote and publish the `main` branch:
+
+```bash
+git remote add origin https://github.com/areebh-dotcom/Customer-Support.git
+git branch -m main
+git push -u origin main
+```
+
+If the branch already exists remotely, run `git fetch origin` beforehand so the local branch can track the upstream history.
+
+### Using a Personal Access Token (PAT)
+
+When authenticating with GitHub from CI or a restricted environment, set a personal access token in the `GITHUB_PAT` environment variable and run the helper script:
+
+```bash
+export GITHUB_PAT=github_pat_xxx   # token with repo scope
+./scripts/push_with_pat.sh areebh-dotcom/Customer-Support main
+```
+
+The script safely configures (or updates) the `origin` remote with the tokenized URL and performs `git push -u origin <branch>`. Override `REMOTE_NAME` or the branch argument if you need to publish to a different remote or branch.
+
+## Next Steps
+The MVP focuses on scripted flows for top intents. Future iterations will integrate a richer knowledge base, analytics instrumentation, multilingual support, and web/mobile chat widgets.

--- a/data/knowledge_base.json
+++ b/data/knowledge_base.json
@@ -1,0 +1,128 @@
+[
+    {
+        "intent": "greeting",
+        "utterances": [
+            "hi",
+            "hello",
+            "hey there",
+            "good morning",
+            "good evening"
+        ],
+        "response": {
+            "text": "Hi there! I'm your Customer Care Assistant. I can help with billing, account access, live events, and device setup. What can I assist you with today?",
+            "suggestions": [
+                "Billing question",
+                "Trouble logging in",
+                "How to watch live events"
+            ]
+        }
+    },
+    {
+        "intent": "billing",
+        "utterances": [
+            "billing issue",
+            "charge on my account",
+            "incorrect bill",
+            "payment failed",
+            "update my card",
+            "need help with billing",
+            "billing help"
+        ],
+        "response": {
+            "text": "It sounds like you have a billing question. Here's what I can do:\n1. Check your subscription status.\n2. Update payment details.\n3. Review recent charges.\nIf you'd like to speak with a specialist, I can collect a few details and start a ticket.",
+            "form": {
+                "title": "Billing support",
+                "fields": [
+                    {
+                        "name": "full_name",
+                        "label": "Full name",
+                        "type": "text",
+                        "required": true
+                    },
+                    {
+                        "name": "email",
+                        "label": "Email address",
+                        "type": "email",
+                        "required": true
+                    },
+                    {
+                        "name": "billing_issue",
+                        "label": "Tell us about the billing issue",
+                        "type": "textarea",
+                        "required": true
+                    }
+                ]
+            },
+            "suggestions": [
+                "Review subscription status",
+                "Update payment method",
+                "Talk to an agent"
+            ]
+        }
+    },
+    {
+        "intent": "login_help",
+        "utterances": [
+            "can't log in",
+            "forgot password",
+            "trouble signing in",
+            "login help",
+            "reset password"
+        ],
+        "response": {
+            "text": "Let's get you back into your account. Try these steps:\n\u2022 Make sure you're using the email connected to your subscription.\n\u2022 If you forgot your password, use the **Reset Password** option on the sign-in page.\n\u2022 Still locked out? I can trigger a password reset email for you.",
+            "suggestions": [
+                "Send me a reset email",
+                "Still can't sign in",
+                "Something else"
+            ]
+        }
+    },
+    {
+        "intent": "live_event",
+        "utterances": [
+            "watch live event",
+            "devices for live events",
+            "streaming live game",
+            "best device for matches",
+            "live event schedule"
+        ],
+        "response": {
+            "text": "We stream live events on web, iOS, Android, Roku, Apple TV, Amazon Fire TV, and Android TV. For the best experience, use a wired connection and close other streaming apps. Need the upcoming schedule?",
+            "suggestions": [
+                "Show live event schedule",
+                "Recommended devices",
+                "Talk to an agent"
+            ]
+        }
+    },
+    {
+        "intent": "goodbye",
+        "utterances": [
+            "thank you",
+            "thanks",
+            "bye",
+            "goodbye",
+            "appreciate it"
+        ],
+        "response": {
+            "text": "Happy to help! If anything else comes up, just let me know. Have a great day!",
+            "suggestions": [
+                "Start over",
+                "No, that's all"
+            ]
+        }
+    },
+    {
+        "intent": "fallback",
+        "utterances": [],
+        "response": {
+            "text": "I'm not sure I have that answer yet. Could you rephrase your question or pick one of the options below? If you'd prefer, I can connect you with a human specialist.",
+            "suggestions": [
+                "Billing question",
+                "Trouble logging in",
+                "Talk to an agent"
+            ]
+        }
+    }
+]

--- a/docs/chatbot_blueprint.md
+++ b/docs/chatbot_blueprint.md
@@ -1,0 +1,107 @@
+# Customer Support Chatbot Blueprint
+
+## 1. Product Vision
+Design an omnichannel virtual assistant that can resolve the majority of subscriber support inquiries instantly while preserving a smooth handoff to human agents for complex cases. The assistant should blend conversational AI with rich UI widgets to mimic the polished experiences illustrated in the reference screenshots.
+
+## 2. Experience Principles
+1. **Trustworthy & Proactive** – Surface relevant answers, policies, and troubleshooting steps before a user needs to ask follow-up questions.
+2. **Guided Interactions** – Present quick-reply chips, carousels, and rich articles that help users discover the right workflow in one tap.
+3. **Human-Ready** – Capture all context (contact information, device, issue details) and provide transparent handoff when escalation is required.
+4. **Insight-Driven** – Collect structured data on every conversation to fuel analytics, churn prevention, and product improvements.
+
+## 3. Key Personas & Use Cases
+- **New Subscribers** – Onboarding help, device compatibility, pricing questions.
+- **Active Subscribers** – Billing, coupon redemption, streaming quality, login issues.
+- **Lapsed / At-Risk Users** – Incentives, tailored messaging, retention outreach.
+
+## 4. Core Capabilities
+### 4.1 Conversational Foundations
+- Multilingual NLU models covering top 5–10 markets (English, Spanish, French, German, Portuguese, etc.).
+- Intent detection, entity extraction, and sentiment analysis to route flows.
+- Context retention across turns with conversation memory, including user profile, device, and subscription tier.
+
+### 4.2 Guided UI Elements
+- **Quick Reply Chips** mirroring "What devices to use for _ live games" or "I have a coupon question" for top intents.
+- **Article Cards** with image, title, summary, and action buttons (e.g., *View article*, *Read more*).
+- **Feedback Widgets** with Yes/No or 1–5 rating after each resolution.
+- **Dynamic Forms** (name, email, device, issue, live-event question) before escalation, similar to MXGP example.
+- **CTA Buttons** (e.g., *Contact Sales*, *Talk to an agent*) persistent at bottom of widget.
+
+### 4.3 Knowledge & Automation
+- CMS-driven knowledge base with versioned articles and auto-suggest.
+- API integrations for account lookup, subscription status, transaction history, entitlement refresh, coupon validation.
+- Automated workflows: password reset, device activation, refund status, outage notifications.
+
+### 4.4 Escalation & Handover
+- Queue selection (billing, tech support, retention).
+- Real-time agent console that displays full transcript, captured form data, and AI recommendations.
+- Email fallback for out-of-hours requests.
+
+### 4.5 Analytics & Insights
+- Real-time dashboard for conversation volume, CSAT, containment rate, intent distribution.
+- Contact reason analysis with trend alerts (mirroring sample analytics screenshot).
+- Persona-based segmentation to personalize offers.
+- Export to BI tools and CRM for LTV tracking.
+
+## 5. Conversation Architecture
+1. **Greeting Layer**
+   - Personalized welcome message using name (if authenticated) or location.
+   - Present top intents as quick replies and an open-text input.
+2. **Intent Resolution Paths**
+   - **Self-Service Flows**: Provide rich article cards, step-by-step instructions, decision trees.
+   - **Troubleshooting Bot**: Interactive forms collecting necessary details and recommending next steps.
+   - **Sales Guidance**: Present carousel of plans, pricing calculators, and CTA to contact sales.
+3. **Fallback & Learning**
+   - Confidence threshold logic: below threshold triggers clarifying questions or agent handoff.
+   - Feedback capture stored for tuning and knowledge gap detection.
+
+## 6. Technical Architecture
+- **Frontend**: Responsive web widget (React/Vue) embeddable in web, mobile, and smart TV apps. Support white-label branding (colors, logos, typography).
+- **Backend**: Node.js or Python microservices orchestrating NLU, knowledge base, and integrations.
+- **NLU Platform**: Consider Google Dialogflow CX, Microsoft Bot Framework with LUIS, or open-source Rasa. Augment with LLM-based retrieval-augmented generation (RAG) for long-form answers.
+- **Knowledge Base**: Markdown/HTML articles stored in headless CMS (Contentful, Strapi) and indexed in vector store (Pinecone, Weaviate) for semantic search.
+- **Analytics Pipeline**: Event streaming (Kafka/Kinesis) into data warehouse (Snowflake/BigQuery) with Looker/Mode dashboards.
+- **Security**: OAuth 2.0 / SSO for authenticated experiences, GDPR-compliant data retention, PII encryption at rest and in transit.
+
+## 7. Integration Checklist
+- Subscription platform (e.g., Cleeng, Stripe, Recurly) for billing inquiries.
+- CRM/Helpdesk (Zendesk, Salesforce Service Cloud) for ticket sync.
+- Email & push notification services for follow-ups.
+- Incident management feed to push outage banners into chat.
+
+## 8. Analytics Requirements
+- **Metrics**: First response time, containment rate, escalation rate, resolution time, CSAT, NPS, churn propensity.
+- **Dashboards**: Intent breakdown by period, device type, region; trending issues; agent utilization; automation savings.
+- **Alerts**: Spike detection for certain intents (e.g., "can't access subscription").
+
+## 9. Content & Tone Guidelines
+- Friendly, concise, brand-aligned voice.
+- Provide empathy for sensitive issues (billing, outages).
+- Offer proactive suggestions and relevant help articles.
+- Always confirm whether the answer solved the problem.
+
+## 10. Implementation Roadmap
+1. **Discovery (Weeks 1–3)**
+   - Audit existing support data, define intents, gather FAQs.
+   - Map integrations and security requirements.
+2. **MVP (Weeks 4–10)**
+   - Build core flows for top 10 intents with quick replies and article cards.
+   - Implement analytics baseline and agent handoff.
+3. **Expansion (Weeks 11–20)**
+   - Add multilingual support, personalization, proactive outreach.
+   - Deploy advanced analytics, churn prediction, and marketing integrations.
+4. **Optimization (Ongoing)**
+   - Continuous training, A/B testing, knowledge updates, and feedback loops.
+
+## 11. Success Criteria
+- 70%+ containment rate within six months.
+- 20% reduction in ticket handling time.
+- CSAT ≥ 4.5/5 for bot-assisted resolutions.
+- Demonstrated lift in subscriber retention for cohorts interacting with the assistant.
+
+## 12. Next Steps
+- Prioritize intents based on recent support data.
+- Choose NLU platform and integration partners.
+- Create UI prototypes reflecting reference designs.
+- Draft knowledge base articles and macro responses.
+- Establish feedback and analytics instrumentation plan.

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -1,0 +1,37 @@
+# Customer Support Chatbot – MVP Implementation Plan
+
+This document captures the discovery notes, design decisions, and backlog for the first functional release of the customer support chatbot. It distills the broader blueprint into concrete workstreams for the MVP.
+
+## 1. Discovery Highlights
+- **Top intents to support first:** billing questions, login help, live event access, general greeting/help, graceful fallbacks.
+- **Tone & brand:** friendly, concise, confident. Empathy for sensitive issues (billing, outages).
+- **Channels:** Start with a web widget + REST API. CLI provided for quick demos.
+- **Success criteria for MVP:** response latency under 500 ms for scripted intents, clear escalation path, ability to capture structured data for billing cases.
+
+## 2. Architecture Snapshot
+```
+User -> Web Widget / CLI -> FastAPI backend -> Rule-based engine -> JSON knowledge base
+```
+- **Backend:** Python FastAPI app served via Uvicorn.
+- **Knowledge base:** JSON file with canonical utterances, responses, and optional forms.
+- **Engine:** Lightweight intent matching via fuzzy similarity (difflib) with fallback handling.
+- **State:** In-memory session memory storing last intent and future slot data.
+
+## 3. Functional Scope for First Release
+1. **Conversational flows** for greeting, billing, login help, live events, goodbye, and fallback.
+2. **Structured responses** including suggestions and forms for data capture.
+3. **REST endpoints** for health check, listing intents, chatting, and resetting a session.
+4. **Developer tooling**: CLI runner and automated unit tests for billing/fallback coverage.
+
+## 4. Backlog & Next Steps
+- Add analytics hooks (event logging per turn).
+- Persist session memory to Redis or database for scalability.
+- Expand knowledge base and integrate with CMS or external APIs.
+- Implement authentication for authenticated user context.
+- Build React widget consuming the REST API with quick replies and forms.
+
+## 5. Operational Runbook
+- Install dependencies with `pip install -r requirements.txt`.
+- Start the API locally: `uvicorn customer_support.api:app --reload`.
+- Run tests with `pytest`.
+- Monitor logs for slow requests; adjust threshold for intent detection as knowledge base grows.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+pydantic==1.10.14
+httpx==0.27.0
+pytest==8.1.1

--- a/scripts/demo_chat.py
+++ b/scripts/demo_chat.py
@@ -1,0 +1,53 @@
+"""Run a scripted conversation against the chatbot engine."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from customer_support.engine import ChatbotEngine
+from customer_support.knowledge import KnowledgeBase
+
+
+def load_engine() -> ChatbotEngine:
+    kb_path = Path(__file__).resolve().parents[1] / "data" / "knowledge_base.json"
+    knowledge_base = KnowledgeBase.from_json(kb_path)
+    return ChatbotEngine(knowledge_base)
+
+
+def run_demo() -> None:
+    engine = load_engine()
+    session_id = "demo"
+    script = [
+        "hello",
+        "I have a billing issue",
+        "thank you",
+    ]
+
+    print("Running scripted chat demo.\n")
+    for turn, message in enumerate(script, start=1):
+        response = engine.respond(session_id, message)
+        header = f"Turn {turn}: You -> {message}"
+        print(header)
+        print("Bot ->", response.response.text)
+        if response.response.suggestions:
+            print("Suggestions:")
+            for suggestion in response.response.suggestions:
+                print(f"  - {suggestion}")
+        if response.response.form:
+            print("Form:")
+            print(f"  {response.response.form.title}")
+            for field in response.response.form.fields:
+                required = "*" if field.required else ""
+                print(f"   - {field.label} ({field.type}){required}")
+        print()
+
+    print("Demo complete.")
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/scripts/push_with_pat.sh
+++ b/scripts/push_with_pat.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") <github-username>/<repository> [branch]
+
+Environment variables:
+  GITHUB_PAT   Personal access token with repo permissions (required)
+  REMOTE_NAME  Git remote name to configure (default: origin)
+
+Example:
+  GITHUB_PAT=ghp_123 ./scripts/push_with_pat.sh areebh-dotcom/Customer-Support main
+USAGE
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 1
+fi
+
+: "${GITHUB_PAT:?GITHUB_PAT must be set to a GitHub personal access token}"
+
+REPO_SLUG="$1"
+BRANCH="${2:-main}"
+REMOTE_NAME="${REMOTE_NAME:-origin}"
+
+REMOTE_URL="https://${GITHUB_PAT}@github.com/${REPO_SLUG}.git"
+
+echo "Configuring remote '${REMOTE_NAME}' for https://github.com/${REPO_SLUG}.git"
+if git remote get-url "${REMOTE_NAME}" >/dev/null 2>&1; then
+  git remote set-url "${REMOTE_NAME}" "${REMOTE_URL}"
+else
+  git remote add "${REMOTE_NAME}" "${REMOTE_URL}"
+fi
+
+echo "Pushing branch '${BRANCH}' to '${REMOTE_NAME}'"
+git push -u "${REMOTE_NAME}" "${BRANCH}"

--- a/src/customer_support/__init__.py
+++ b/src/customer_support/__init__.py
@@ -1,0 +1,1 @@
+"""Customer Support chatbot package."""

--- a/src/customer_support/api.py
+++ b/src/customer_support/api.py
@@ -1,0 +1,97 @@
+"""FastAPI application exposing the chatbot engine."""
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+from fastapi import Body, Depends, FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from .engine import ChatbotEngine
+from .knowledge import KnowledgeBase
+
+TEMPLATE_PATH = Path(__file__).resolve().parent / "templates" / "index.html"
+
+
+app = FastAPI(title="Customer Support Chatbot", version="0.1.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
+
+
+def kb_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "data" / "knowledge_base.json"
+
+
+@lru_cache()
+def knowledge_base() -> KnowledgeBase:
+    return KnowledgeBase.from_json(kb_path())
+
+
+@lru_cache()
+def engine() -> ChatbotEngine:
+    return ChatbotEngine(knowledge_base())
+
+
+@app.get("/health")
+def healthcheck() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/", response_class=HTMLResponse, include_in_schema=False)
+def index() -> HTMLResponse:
+    return HTMLResponse(TEMPLATE_PATH.read_text(encoding="utf-8"))
+
+
+@app.get("/links", response_class=JSONResponse)
+def useful_links(request: Request) -> Dict[str, str]:
+    base_url = str(request.base_url).rstrip("/")
+    docs_url = f"{base_url}/docs"
+    return {
+        "message": "Customer Support Chatbot API is running.",
+        "docs_url": docs_url,
+        "chat_endpoint": f"{base_url}/chat",
+    }
+
+
+@app.get("/intents")
+def list_intents(kb: KnowledgeBase = Depends(knowledge_base)) -> Dict[str, Dict[str, Any]]:
+    return kb.to_dict()
+
+
+@app.post("/chat")
+def chat(payload: Dict[str, Any] = Body(...), bot: ChatbotEngine = Depends(engine)) -> Dict[str, Any]:
+    session_id = str(payload.get("session_id", "anon"))
+    message = str(payload.get("message", "")).strip()
+    if not message:
+        return {
+            "session_id": session_id,
+            "intent": "fallback",
+            "confidence": 0.0,
+            "response": {
+                "text": "Could you share a bit more detail so I can assist you?",
+                "suggestions": ["Billing question", "Trouble logging in", "Talk to an agent"],
+            },
+            "memory": {},
+            "history": [],
+        }
+
+    response = bot.respond(session_id, message)
+    return response.to_dict()
+
+
+@app.post("/sessions/{session_id}/reset")
+def reset_session(session_id: str, bot: ChatbotEngine = Depends(engine)) -> Dict[str, str]:
+    bot.reset_session(session_id)
+    return {"status": "reset", "session_id": session_id}
+
+
+@app.get("/sessions/{session_id}")
+def session_state(session_id: str, bot: ChatbotEngine = Depends(engine)) -> Dict[str, Any]:
+    return bot.session_state(session_id)

--- a/src/customer_support/cli.py
+++ b/src/customer_support/cli.py
@@ -1,0 +1,38 @@
+"""Simple command line interface for manual testing of the chatbot engine."""
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+from .engine import ChatbotEngine
+from .knowledge import KnowledgeBase
+
+
+def run_cli() -> None:
+    kb_path = Path(__file__).resolve().parents[2] / "data" / "knowledge_base.json"
+    engine = ChatbotEngine(KnowledgeBase.from_json(kb_path))
+    session_id = str(uuid.uuid4())
+    print("Customer Support Assistant (type 'exit' to quit)")
+
+    while True:
+        message = input("You: ").strip()
+        if message.lower() in {"exit", "quit"}:
+            break
+        if not message:
+            continue
+        response = engine.respond(session_id, message)
+        print(f"Bot [{response.intent} @ {response.confidence:.2f}]: {response.response.text}")
+        if response.response.suggestions:
+            print("Suggestions:")
+            for suggestion in response.response.suggestions:
+                print(f"  - {suggestion}")
+        if response.response.form:
+            print(response.response.form.title or "Form")
+            for field in response.response.form.fields:
+                required = "*" if field.required else ""
+                print(f"  - {field.label} ({field.type}){required}")
+    print("Goodbye!")
+
+
+if __name__ == "__main__":
+    run_cli()

--- a/src/customer_support/engine.py
+++ b/src/customer_support/engine.py
@@ -1,0 +1,89 @@
+"""Core rule-based chatbot engine."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Any, Dict
+
+from .knowledge import KnowledgeBase
+from .models import ChatResponse, Intent, Memory, ResponsePayload
+
+
+@dataclass
+class MatchResult:
+    intent: Intent
+    confidence: float
+
+
+class ChatbotEngine:
+    """Tiny rule-based engine capable of serving MVP chat requests."""
+
+    def __init__(self, knowledge_base: KnowledgeBase, threshold: float = 0.55):
+        self.knowledge_base = knowledge_base
+        self.threshold = threshold
+        self._memory: Dict[str, Memory] = {}
+
+    def _memory_for(self, session_id: str) -> Memory:
+        if session_id not in self._memory:
+            self._memory[session_id] = Memory(session_id=session_id)
+        return self._memory[session_id]
+
+    def _similarity(self, a: str, b: str) -> float:
+        return SequenceMatcher(None, a.lower(), b.lower()).ratio()
+
+    def _match_intent(self, text: str) -> MatchResult:
+        best_intent = None
+        best_score = 0.0
+        normalized = text.strip().lower()
+
+        for intent in self.knowledge_base.intents():
+            if not intent.utterances:
+                continue
+            for utterance in intent.utterances:
+                score = self._similarity(normalized, utterance)
+                if score > best_score:
+                    best_score = score
+                    best_intent = intent
+
+        if best_intent and best_score >= self.threshold:
+            return MatchResult(intent=best_intent, confidence=best_score)
+
+        fallback = self.knowledge_base.get("fallback")
+        return MatchResult(intent=fallback, confidence=best_score)
+
+    def respond(self, session_id: str, message: str) -> ChatResponse:
+        memory = self._memory_for(session_id)
+        match = self._match_intent(message)
+
+        memory.last_intent = match.intent.name
+        response_payload: ResponsePayload = match.intent.response
+
+        memory.history.append({"role": "user", "text": message})
+        memory.history.append(
+            {
+                "role": "assistant",
+                "intent": match.intent.name,
+                "text": response_payload.text,
+            }
+        )
+
+        return ChatResponse(
+            session_id=session_id,
+            intent=match.intent.name,
+            confidence=round(match.confidence, 3),
+            response=response_payload,
+            memory=memory.slots,
+            history=memory.history,
+        )
+
+    def reset_session(self, session_id: str) -> None:
+        self._memory.pop(session_id, None)
+
+    def stats(self) -> Dict[str, Dict[str, list]]:
+        return self.knowledge_base.to_dict()
+
+    def session_state(self, session_id: str) -> Dict[str, Any]:
+        memory = self._memory.get(session_id)
+        if memory is None:
+            memory = Memory(session_id=session_id)
+        return memory.to_dict()

--- a/src/customer_support/knowledge.py
+++ b/src/customer_support/knowledge.py
@@ -1,0 +1,45 @@
+"""Knowledge base loader for the customer support chatbot."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from .models import Intent, ResponsePayload
+
+
+class KnowledgeBase:
+    """Loads and stores intents defined in a JSON file."""
+
+    def __init__(self, intents: List[Intent]):
+        self._intents = {intent.name: intent for intent in intents}
+
+    @classmethod
+    def from_json(cls, path: Path) -> "KnowledgeBase":
+        raw = json.loads(path.read_text())
+        intents: List[Intent] = []
+        for entry in raw:
+            response = ResponsePayload.from_dict(entry["response"])
+            intents.append(
+                Intent(
+                    name=entry["intent"],
+                    utterances=[u.lower() for u in entry.get("utterances", [])],
+                    response=response,
+                )
+            )
+        return cls(intents)
+
+    def intents(self) -> Iterable[Intent]:
+        return self._intents.values()
+
+    def get(self, name: str) -> Intent:
+        return self._intents[name]
+
+    def to_dict(self) -> Dict[str, Dict[str, List[str]]]:
+        return {
+            intent.name: {
+                "utterances": intent.utterances,
+                "suggestions": intent.response.suggestions,
+            }
+            for intent in self._intents.values()
+        }

--- a/src/customer_support/models.py
+++ b/src/customer_support/models.py
@@ -1,0 +1,125 @@
+"""Domain models for the customer support chatbot."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class FormField:
+    """Schema for a dynamic form field shown to the user."""
+
+    name: str
+    label: str
+    type: str
+    required: bool = False
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "FormField":
+        return cls(
+            name=str(data["name"]),
+            label=str(data.get("label", "")),
+            type=str(data.get("type", "text")),
+            required=bool(data.get("required", False)),
+        )
+
+
+@dataclass
+class FormSchema:
+    """Dynamic form attached to an intent response."""
+
+    title: str
+    fields: List[FormField] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "FormSchema":
+        fields = [FormField.from_dict(f) for f in data.get("fields", [])]
+        return cls(title=str(data.get("title", "")), fields=fields)
+
+
+@dataclass
+class ResponsePayload:
+    """Response payload returned for a resolved intent."""
+
+    text: str
+    suggestions: List[str] = field(default_factory=list)
+    form: Optional[FormSchema] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "ResponsePayload":
+        form_data = data.get("form")
+        form = FormSchema.from_dict(form_data) if isinstance(form_data, dict) else None
+        return cls(
+            text=str(data.get("text", "")),
+            suggestions=[str(item) for item in data.get("suggestions", [])],
+            form=form,
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "text": self.text,
+            "suggestions": list(self.suggestions),
+        }
+        if self.form:
+            payload["form"] = {
+                "title": self.form.title,
+                "fields": [field.__dict__ for field in self.form.fields],
+            }
+        return payload
+
+
+@dataclass
+class Intent:
+    """Canonical intent description loaded from the knowledge base."""
+
+    name: str
+    utterances: List[str]
+    response: ResponsePayload
+
+
+@dataclass
+class Memory:
+    """Conversation state tracked across user turns."""
+
+    session_id: str
+    last_intent: Optional[str] = None
+    slots: Dict[str, str] = field(default_factory=dict)
+    history: List[Dict[str, str]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "session_id": self.session_id,
+            "last_intent": self.last_intent,
+            "slots": dict(self.slots),
+            "history": [dict(entry) for entry in self.history],
+        }
+
+
+@dataclass
+class ChatRequest:
+    """Incoming message payload for the API."""
+
+    message: str
+    session_id: str = "anon"
+
+
+@dataclass
+class ChatResponse:
+    """Response returned by the chatbot engine via the API."""
+
+    session_id: str
+    intent: str
+    confidence: float
+    response: ResponsePayload
+    memory: Dict[str, str] = field(default_factory=dict)
+    history: List[Dict[str, str]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "session_id": self.session_id,
+            "intent": self.intent,
+            "confidence": self.confidence,
+            "response": self.response.to_dict(),
+            "memory": dict(self.memory),
+            "history": [dict(entry) for entry in self.history],
+        }

--- a/src/customer_support/templates/index.html
+++ b/src/customer_support/templates/index.html
@@ -146,6 +146,14 @@
         background: rgba(47, 84, 235, 0.12);
         color: var(--primary-dark);
         margin-bottom: 0.4rem;
+        text-transform: capitalize;
+      }
+
+      .message .timestamp {
+        display: block;
+        margin-top: 0.6rem;
+        font-size: 0.75rem;
+        color: #64748b;
       }
 
       .suggestions {
@@ -267,6 +275,47 @@
       .hidden {
         display: none !important;
       }
+
+      .typing-indicator {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.5rem 0.8rem;
+        border-radius: 999px;
+        background: rgba(47, 84, 235, 0.15);
+        color: var(--primary-dark);
+        font-size: 0.85rem;
+      }
+
+      .typing-indicator span {
+        display: inline-block;
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: currentColor;
+        animation: bounce 0.9s infinite ease-in-out;
+      }
+
+      .typing-indicator span:nth-child(2) {
+        animation-delay: 0.15s;
+      }
+
+      .typing-indicator span:nth-child(3) {
+        animation-delay: 0.3s;
+      }
+
+      @keyframes bounce {
+        0%,
+        80%,
+        100% {
+          transform: translateY(0);
+          opacity: 0.4;
+        }
+        40% {
+          transform: translateY(-4px);
+          opacity: 1;
+        }
+      }
     </style>
   </head>
   <body>
@@ -279,7 +328,7 @@
             quick actions or type your question to start a conversation.
           </p>
         </div>
-        <div class="status" id="connection-status">Ready to help.</div>
+        <div class="status" id="connection-status">Loading assistant...</div>
         <div class="quick-actions" id="quick-actions"></div>
         <div class="status">
           Tip: Forms submitted here are shared with human specialists when escalation is needed.
@@ -320,8 +369,16 @@
       })();
 
       let isSending = false;
+      let typingIndicator = null;
 
-      function createMessageElement(role, text, intent = null) {
+      function formatTimestamp(date) {
+        return new Intl.DateTimeFormat(undefined, {
+          hour: "2-digit",
+          minute: "2-digit",
+        }).format(date);
+      }
+
+      function createMessageElement(role, text, intent = null, timestamp = null) {
         const template = document.getElementById("message-template");
         const element = template.content.firstElementChild.cloneNode(true);
         element.classList.add(role);
@@ -340,13 +397,23 @@
           p.textContent = paragraph;
           content.appendChild(p);
         });
+
+        if (timestamp) {
+          const time = document.createElement("span");
+          time.className = "timestamp";
+          time.textContent = timestamp;
+          content.appendChild(time);
+        }
+
         return element;
       }
 
-      function appendMessage(role, text, intent) {
-        const message = createMessageElement(role, text, intent);
+      function appendMessage(role, text, intent = null, options = {}) {
+        const timestamp = options.timestamp ?? formatTimestamp(new Date());
+        const message = createMessageElement(role, text, intent, timestamp);
         transcript.appendChild(message);
         transcript.scrollTop = transcript.scrollHeight;
+        return message;
       }
 
       function renderSuggestions(suggestions) {
@@ -425,6 +492,37 @@
         transcript.scrollTop = transcript.scrollHeight;
       }
 
+      function showTypingIndicator() {
+        if (typingIndicator) {
+          return;
+        }
+        typingIndicator = document.createElement("div");
+        typingIndicator.className = "typing-indicator";
+        typingIndicator.setAttribute("aria-live", "polite");
+        typingIndicator.innerHTML = '<span></span><span></span><span></span>';
+        const wrapper = document.createElement("div");
+        wrapper.className = "message assistant";
+        wrapper.appendChild(typingIndicator);
+        transcript.appendChild(wrapper);
+        transcript.scrollTop = transcript.scrollHeight;
+      }
+
+      function hideTypingIndicator() {
+        if (!typingIndicator) {
+          return;
+        }
+        const container = typingIndicator.closest(".message");
+        if (container) {
+          container.remove();
+        }
+        typingIndicator = null;
+      }
+
+      function setComposerDisabled(disabled) {
+        messageInput.disabled = disabled;
+        sendButton.disabled = disabled;
+      }
+
       async function sendMessage(text) {
         if (!text || !text.trim() || isSending) {
           return;
@@ -434,8 +532,10 @@
         messageInput.value = "";
         renderSuggestions([]);
         isSending = true;
-        statusLabel.textContent = "Thinking...";
+        statusLabel.textContent = "Assistant is typing...";
         statusLabel.classList.remove("hidden");
+        setComposerDisabled(true);
+        showTypingIndicator();
 
         try {
           const response = await fetch("/chat", {
@@ -451,11 +551,13 @@
           }
 
           const payload = await response.json();
+          hideTypingIndicator();
           appendMessage("assistant", payload.response.text, payload.intent);
           renderSuggestions(payload.response.suggestions);
           renderForm(payload.response.form);
           statusLabel.textContent = `Intent: ${payload.intent} (confidence ${payload.confidence.toFixed(2)})`;
         } catch (error) {
+          hideTypingIndicator();
           appendMessage(
             "assistant",
             "I couldn't reach the support service just now. Please try again or refresh the page.",
@@ -465,6 +567,8 @@
           console.error(error);
         } finally {
           isSending = false;
+          setComposerDisabled(false);
+          messageInput.focus();
         }
       }
 
@@ -476,17 +580,43 @@
         }
       });
 
-      // Kick off greeting
-      appendMessage(
-        "assistant",
-        "Hi there! I'm your Customer Care Assistant. Ask me about billing, live events, or account access to get started.",
-        "greeting"
-      );
-      renderSuggestions([
-        "Billing question",
-        "Trouble logging in",
-        "How to watch live events",
-      ]);
+      async function bootstrap() {
+        appendMessage(
+          "assistant",
+          "Hi there! I'm your Customer Care Assistant. Ask me about billing, live events, or account access to get started.",
+          "greeting",
+          { timestamp: formatTimestamp(new Date()) }
+        );
+        renderSuggestions([
+          "Billing question",
+          "Trouble logging in",
+          "How to watch live events",
+        ]);
+
+        try {
+          const response = await fetch(`/sessions/${sessionId}`);
+          if (!response.ok) {
+            throw new Error("Unable to load previous conversation");
+          }
+          const data = await response.json();
+          if (Array.isArray(data.history) && data.history.length > 0) {
+            transcript.innerHTML = "";
+            data.history.forEach((entry) => {
+              const role = entry.role === "assistant" ? "assistant" : "user";
+              appendMessage(role, entry.text, entry.intent || null, {
+                timestamp: formatTimestamp(new Date()),
+              });
+            });
+          }
+          statusLabel.textContent = "Ready to help.";
+        } catch (error) {
+          statusLabel.textContent = "Ready to help (offline history unavailable).";
+          console.warn(error);
+        }
+        messageInput.focus();
+      }
+
+      bootstrap();
     </script>
   </body>
 </html>

--- a/src/customer_support/templates/index.html
+++ b/src/customer_support/templates/index.html
@@ -1,0 +1,492 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Customer Support Assistant</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg-color: #f4f6fb;
+        --card-color: #ffffff;
+        --border-color: #d8deed;
+        --primary: #2f54eb;
+        --primary-dark: #1d39c4;
+        --text-color: #1f2933;
+        --assistant-bg: #eef2ff;
+        --user-bg: #d1f7c4;
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+        background: linear-gradient(135deg, #dee5ff, #f4f6fb);
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .app-shell {
+        width: min(100%, 960px);
+        height: min(90vh, 720px);
+        display: grid;
+        grid-template-columns: 280px 1fr;
+        gap: 1.5rem;
+        padding: 1.5rem;
+        box-sizing: border-box;
+      }
+
+      @media (max-width: 900px) {
+        .app-shell {
+          grid-template-columns: 1fr;
+          height: auto;
+        }
+      }
+
+      .card {
+        background: var(--card-color);
+        border-radius: 20px;
+        box-shadow: 0 18px 35px rgba(31, 45, 61, 0.15);
+        border: 1px solid rgba(47, 84, 235, 0.08);
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+
+      .sidebar {
+        padding: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .sidebar h1 {
+        font-size: 1.5rem;
+        margin: 0;
+        color: var(--primary);
+      }
+
+      .sidebar p {
+        margin: 0;
+        color: #475569;
+        line-height: 1.5;
+      }
+
+      .quick-actions {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .quick-actions button {
+        border: none;
+        border-radius: 12px;
+        padding: 0.75rem 1rem;
+        text-align: left;
+        font-weight: 600;
+        background: rgba(47, 84, 235, 0.08);
+        color: var(--primary);
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.2s ease;
+      }
+
+      .quick-actions button:hover,
+      .quick-actions button:focus {
+        transform: translateY(-2px);
+        box-shadow: 0 12px 20px rgba(47, 84, 235, 0.2);
+        outline: none;
+      }
+
+      .transcript {
+        flex: 1 1 auto;
+        padding: 1.5rem;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        background: radial-gradient(circle at top left, rgba(47, 84, 235, 0.15), transparent 60%);
+      }
+
+      .message {
+        max-width: 75%;
+        padding: 1rem 1.25rem;
+        border-radius: 18px;
+        line-height: 1.5;
+        box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+        position: relative;
+      }
+
+      .message.user {
+        margin-left: auto;
+        background: var(--user-bg);
+        color: #0f172a;
+      }
+
+      .message.assistant {
+        background: var(--assistant-bg);
+      }
+
+      .message.assistant::before {
+        content: "\2728";
+        position: absolute;
+        top: -12px;
+        left: -12px;
+        font-size: 1.25rem;
+      }
+
+      .message .intent-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        font-size: 0.75rem;
+        padding: 0.15rem 0.55rem;
+        border-radius: 999px;
+        background: rgba(47, 84, 235, 0.12);
+        color: var(--primary-dark);
+        margin-bottom: 0.4rem;
+      }
+
+      .suggestions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 0.85rem;
+      }
+
+      .suggestions button {
+        padding: 0.5rem 0.9rem;
+        border-radius: 999px;
+        border: 1px solid var(--border-color);
+        background: #fff;
+        cursor: pointer;
+        transition: background 0.2s ease;
+      }
+
+      .suggestions button:hover,
+      .suggestions button:focus {
+        background: rgba(47, 84, 235, 0.1);
+        outline: none;
+      }
+
+      .composer {
+        border-top: 1px solid rgba(148, 163, 184, 0.2);
+        padding: 1rem 1.5rem 1.5rem;
+        display: flex;
+        gap: 1rem;
+        align-items: flex-end;
+        background: var(--card-color);
+      }
+
+      .composer textarea {
+        flex: 1 1 auto;
+        resize: none;
+        min-height: 60px;
+        max-height: 160px;
+        border-radius: 12px;
+        border: 1px solid var(--border-color);
+        padding: 0.75rem 1rem;
+        font-size: 1rem;
+        line-height: 1.5;
+        font-family: inherit;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .composer textarea:focus {
+        border-color: var(--primary);
+        box-shadow: 0 0 0 3px rgba(47, 84, 235, 0.15);
+        outline: none;
+      }
+
+      .composer button {
+        background: var(--primary);
+        color: white;
+        border: none;
+        border-radius: 12px;
+        padding: 0.85rem 1.75rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.15s ease;
+      }
+
+      .composer button:hover,
+      .composer button:focus {
+        background: var(--primary-dark);
+        transform: translateY(-1px);
+        outline: none;
+      }
+
+      form.intent-form {
+        margin-top: 1rem;
+        padding: 1rem;
+        border: 1px dashed rgba(47, 84, 235, 0.3);
+        border-radius: 12px;
+        background: rgba(47, 84, 235, 0.06);
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      form.intent-form h3 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--primary-dark);
+      }
+
+      form.intent-form label {
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: #1e293b;
+      }
+
+      form.intent-form input,
+      form.intent-form textarea {
+        border-radius: 10px;
+        border: 1px solid rgba(148, 163, 184, 0.6);
+        padding: 0.6rem 0.75rem;
+        font-family: inherit;
+      }
+
+      form.intent-form button {
+        align-self: flex-start;
+        padding: 0.6rem 1.2rem;
+        border-radius: 999px;
+        border: none;
+        background: var(--primary);
+        color: white;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      .status {
+        font-size: 0.85rem;
+        color: #475569;
+      }
+
+      .hidden {
+        display: none !important;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app-shell">
+      <section class="card sidebar">
+        <div>
+          <h1>Customer Care Assistant</h1>
+          <p>
+            Get instant help for billing, account access, live events, and more. Use the
+            quick actions or type your question to start a conversation.
+          </p>
+        </div>
+        <div class="status" id="connection-status">Ready to help.</div>
+        <div class="quick-actions" id="quick-actions"></div>
+        <div class="status">
+          Tip: Forms submitted here are shared with human specialists when escalation is needed.
+        </div>
+      </section>
+      <section class="card" aria-live="polite">
+        <div class="transcript" id="transcript"></div>
+        <div class="composer">
+          <textarea
+            id="message-input"
+            placeholder="Ask me anything about your subscription..."
+            rows="2"
+            aria-label="Type your message"
+          ></textarea>
+          <button id="send-button" type="button">Send</button>
+        </div>
+      </section>
+    </div>
+
+    <template id="message-template">
+      <div class="message">
+        <div class="content"></div>
+      </div>
+    </template>
+
+    <script>
+      const transcript = document.getElementById("transcript");
+      const messageInput = document.getElementById("message-input");
+      const sendButton = document.getElementById("send-button");
+      const quickActionsContainer = document.getElementById("quick-actions");
+      const statusLabel = document.getElementById("connection-status");
+
+      const sessionId = (() => {
+        if (crypto.randomUUID) {
+          return crypto.randomUUID();
+        }
+        return "web-" + Math.random().toString(36).slice(2);
+      })();
+
+      let isSending = false;
+
+      function createMessageElement(role, text, intent = null) {
+        const template = document.getElementById("message-template");
+        const element = template.content.firstElementChild.cloneNode(true);
+        element.classList.add(role);
+        const content = element.querySelector(".content");
+
+        if (role === "assistant" && intent) {
+          const chip = document.createElement("span");
+          chip.className = "intent-tag";
+          chip.textContent = intent.replace(/_/g, " ");
+          content.appendChild(chip);
+        }
+
+        const paragraphs = text.split(/\n+/);
+        paragraphs.forEach((paragraph) => {
+          const p = document.createElement("p");
+          p.textContent = paragraph;
+          content.appendChild(p);
+        });
+        return element;
+      }
+
+      function appendMessage(role, text, intent) {
+        const message = createMessageElement(role, text, intent);
+        transcript.appendChild(message);
+        transcript.scrollTop = transcript.scrollHeight;
+      }
+
+      function renderSuggestions(suggestions) {
+        quickActionsContainer.innerHTML = "";
+        if (!suggestions || suggestions.length === 0) {
+          return;
+        }
+        suggestions.forEach((suggestion) => {
+          const btn = document.createElement("button");
+          btn.type = "button";
+          btn.textContent = suggestion;
+          btn.addEventListener("click", () => sendMessage(suggestion));
+          quickActionsContainer.appendChild(btn);
+        });
+      }
+
+      function renderForm(formPayload) {
+        const existing = document.querySelector("form.intent-form");
+        if (existing) {
+          existing.remove();
+        }
+        if (!formPayload) {
+          return;
+        }
+
+        const form = document.createElement("form");
+        form.className = "intent-form";
+        form.dataset.intent = formPayload.title || "Form";
+
+        const heading = document.createElement("h3");
+        heading.textContent = formPayload.title || "Provide details";
+        form.appendChild(heading);
+
+        formPayload.fields.forEach((field) => {
+          const wrapper = document.createElement("div");
+
+          const label = document.createElement("label");
+          label.textContent = field.label || field.name;
+          label.setAttribute("for", field.name);
+          wrapper.appendChild(label);
+
+          let input;
+          if (field.type === "textarea") {
+            input = document.createElement("textarea");
+            input.rows = 3;
+          } else {
+            input = document.createElement("input");
+            input.type = field.type || "text";
+          }
+          input.id = field.name;
+          input.name = field.name;
+          if (field.required) {
+            input.required = true;
+          }
+          wrapper.appendChild(input);
+          form.appendChild(wrapper);
+        });
+
+        const submit = document.createElement("button");
+        submit.type = "submit";
+        submit.textContent = "Submit details";
+        form.appendChild(submit);
+
+        form.addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const formData = new FormData(form);
+          const summary = Array.from(formData.entries())
+            .map(([key, value]) => `${key}: ${value}`)
+            .join("; ");
+          appendMessage("user", summary);
+          form.remove();
+          await sendMessage(`Here are my details -> ${summary}`);
+        });
+
+        transcript.appendChild(form);
+        transcript.scrollTop = transcript.scrollHeight;
+      }
+
+      async function sendMessage(text) {
+        if (!text || !text.trim() || isSending) {
+          return;
+        }
+        const message = text.trim();
+        appendMessage("user", message);
+        messageInput.value = "";
+        renderSuggestions([]);
+        isSending = true;
+        statusLabel.textContent = "Thinking...";
+        statusLabel.classList.remove("hidden");
+
+        try {
+          const response = await fetch("/chat", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ session_id: sessionId, message }),
+          });
+
+          if (!response.ok) {
+            throw new Error(`Request failed: ${response.status}`);
+          }
+
+          const payload = await response.json();
+          appendMessage("assistant", payload.response.text, payload.intent);
+          renderSuggestions(payload.response.suggestions);
+          renderForm(payload.response.form);
+          statusLabel.textContent = `Intent: ${payload.intent} (confidence ${payload.confidence.toFixed(2)})`;
+        } catch (error) {
+          appendMessage(
+            "assistant",
+            "I couldn't reach the support service just now. Please try again or refresh the page.",
+            "system_error"
+          );
+          statusLabel.textContent = "Connection issue – retry in a moment.";
+          console.error(error);
+        } finally {
+          isSending = false;
+        }
+      }
+
+      sendButton.addEventListener("click", () => sendMessage(messageInput.value));
+      messageInput.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && !event.shiftKey) {
+          event.preventDefault();
+          sendMessage(messageInput.value);
+        }
+      });
+
+      // Kick off greeting
+      appendMessage(
+        "assistant",
+        "Hi there! I'm your Customer Care Assistant. Ask me about billing, live events, or account access to get started.",
+        "greeting"
+      );
+      renderSuggestions([
+        "Billing question",
+        "Trouble logging in",
+        "How to watch live events",
+      ]);
+    </script>
+  </body>
+</html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,77 @@
+from fastapi.testclient import TestClient
+
+from customer_support.api import app
+
+
+client = TestClient(app)
+
+
+def test_health_endpoint():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_index_serves_frontend():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "Customer Care Assistant" in body
+    assert "quick-actions" in body
+
+
+def test_links_endpoint_provides_docs_link():
+    response = client.get("/links")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["docs_url"].endswith("/docs")
+    assert payload["chat_endpoint"].endswith("/chat")
+
+
+def test_chat_endpoint_handles_known_intent():
+    response = client.post(
+        "/chat",
+        json={"session_id": "pytest", "message": "Need help with billing"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["intent"] == "billing"
+    assert "billing" in payload["response"]["text"].lower()
+    assert len(payload["history"]) == 2
+    assert payload["history"][0] == {"role": "user", "text": "Need help with billing"}
+    assert payload["history"][1]["intent"] == "billing"
+
+
+def test_chat_endpoint_handles_empty_message():
+    response = client.post(
+        "/chat",
+        json={"session_id": "pytest", "message": "   "},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["intent"] == "fallback"
+    assert payload["confidence"] == 0.0
+    assert payload["history"] == []
+
+
+def test_session_state_endpoint_tracks_history():
+    session_id = "pytest-history"
+
+    initial = client.get(f"/sessions/{session_id}")
+    assert initial.status_code == 200
+    assert initial.json()["history"] == []
+
+    client.post(
+        "/chat",
+        json={"session_id": session_id, "message": "hi"},
+    )
+
+    response = client.get(f"/sessions/{session_id}")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["session_id"] == session_id
+    assert payload["history"][0] == {"role": "user", "text": "hi"}
+    assert payload["history"][1]["intent"] == "greeting"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from customer_support.engine import ChatbotEngine
+from customer_support.knowledge import KnowledgeBase
+
+
+def load_engine() -> ChatbotEngine:
+    kb_path = Path(__file__).resolve().parents[1] / "data" / "knowledge_base.json"
+    kb = KnowledgeBase.from_json(kb_path)
+    return ChatbotEngine(kb)
+
+
+def test_engine_matches_billing_intent():
+    engine = load_engine()
+
+    response = engine.respond("test", "I have a billing issue")
+
+    assert response.intent == "billing"
+    assert "billing" in response.response.text.lower()
+    assert response.history[0] == {"role": "user", "text": "I have a billing issue"}
+    assert response.history[1]["intent"] == "billing"
+
+
+def test_engine_falls_back_for_unknown():
+    engine = load_engine()
+
+    response = engine.respond("test", "Tell me about space rockets")
+
+    assert response.intent == "fallback"
+    assert "not sure" in response.response.text.lower()
+
+
+def test_session_state_reports_history():
+    engine = load_engine()
+    session_id = "stateful"
+
+    empty_state = engine.session_state(session_id)
+    assert empty_state["history"] == []
+
+    engine.respond(session_id, "hi")
+
+    state = engine.session_state(session_id)
+    assert state["history"][0] == {"role": "user", "text": "hi"}
+    assert state["history"][1]["intent"] == "greeting"


### PR DESCRIPTION
## Summary
- serve a polished single-page chatbot experience at the root URL using a FastAPI HTML response
- surface the JSON landing links under /links and refresh the README with UI guidance
- cover the new frontend route and links endpoint with API tests
- document the --app-dir usage and Makefile helper so uvicorn can locate the source package

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e65f49cf0083278aeca695ca41f63b